### PR TITLE
Bump timeout to 60s if using an external pylama or pylint

### DIFF
--- a/lib/linter-pylama.coffee
+++ b/lib/linter-pylama.coffee
@@ -204,6 +204,11 @@ class LinterPylama
     else
       command = @interpreter
       args.unshift @pylamaPath
+    # An external Python variant, pylama or pylint can take their time
+    if @usePyLint or @pylamaVersion is 'external'
+        timeout = 60000
+    else
+        timeout = 10000
     info = {
       fileName: originFileName
       command: command
@@ -212,6 +217,7 @@ class LinterPylama
         env: env
         cwd: cwd
         stream: 'both'
+        timeout: timeout
       }
     }
 


### PR DESCRIPTION
Originally thought this could go as a user configurable field into atom-linter, but that was shot down:
https://github.com/steelbrain/atom-linter/issues/174

Pylint takes its time on larger projects and the default 10s timeout is just short of useful there.

Also as Jython or a project managed interpreter with massively complex site-packages setups can take their time to just fire up the interpreter pre-linting I'm also making it bump the timeout up when using an external installation.

I've yet to see any of the mentioned scenarios to have an execution time exceeding 30s, so I've deemed 60s a safe limit to cover these cases even on slower computers.